### PR TITLE
Update 05-Reliability.Rmd

### DIFF
--- a/05-Reliability.Rmd
+++ b/05-Reliability.Rmd
@@ -27,19 +27,19 @@ Focusing on this week's materials, make sure you can:
 
 ### Planning for Practice
 
-In each of these lessons I provide suggestions for practice that allow you to select one or more problems that are graded in difficulty. The practice problems are the start of a larger project that spans multiple lessons. Therefore,if possible, please use a dataset that has item-level data for which there is a theorized total scale score as well as two or more subscales.  With each of these options I encourage you to:
+In each of these lessons, I provide suggestions for practice that allow you to select one or more problems that are graded in difficulty. The practice problems are the start of a larger project that spans multiple lessons. Therefore, if possible, please use a dataset that has item-level data for which there is a theorized total scale score as well as two or more subscales.  With each of these options I encourage you to:
 
-* Format (i.e., rescore if necessary) a dataset so that it is possible to calculates estimates of internal consistency
+* Format (i.e., rescore, if necessary) a dataset so that it is possible to calculates estimates of internal consistency
 * Calculate and report the alpha coefficient for a total scale scores and subscales (if the scale has them)
 * Calculate and report $\omega_{t}$ and $\omega_{h}$. With these two determine what proportion of the variance is due to all the factors, error, and *g*.
 * Calculate total and subscale scores.
 * Describe other reliability estimates that would be appropriate for the measure you are evaluating.
 
-I encourage you to use data that allows for the possibility of a total scale score as well as two or more subscales. This will allow you to continue using it in some of the lessons that follow.
+Again, I encourage you to use data that allows for the possibility of a total scale score as well as two or more subscales. This will allow you to continue using it in some of the lessons that follow.
 
 ### Readings & Resources
 
-In preparing this chapter, I drew heavily from the following resource(s). Other resources are cited (when possible, linked) in the text with complete citations in the reference list.
+In preparing this chapter, I drew heavily from the following resource(s). Other resources are cited (and linked, when possible) in the text with complete citations in the reference list.
 
 * Jhangiani, R. S., Chiang, I.-C. A., Cuttler, C., & Leighton, D. C. (2019). Reliability and Validity. In *Research Methods in Psychology*. https://doi.org/10.17605/OSF.IO/HF7DQ
 * Revelle, W., & Condon, D. M. (2019a). Reliability from α to ω: A tutorial. Psychological Assessment. https://doi.org/10.1037/pas0000754
@@ -68,9 +68,9 @@ if(!require(qualtRics)){install.packages("qualtRics")}
 
 ### Begins with Classical Test Theory (CTT)
 
-CTT is based on Spearman's (1904) *true-score model*, where
+CTT is based on Spearman's (1904) *true-score model* where:
 
-* an observed score is conceived of as consisting of two components – a true component and an error component
+* an observed score is conceived of as consisting of two components – a true component and an error component (comment: this sentence is confusing for me, specifically with the "an observed score is conceived of as consisting of two components" - I think the "of as" is throwing me off)
 * X = T + E
   + X = the fallible, observed/manifest score, obtained under ideal or perfect conditions of measurement (these conditions never exist);
   + T = the true/latent score (that will likely remain unknown); and
@@ -82,14 +82,14 @@ CTT is based on Spearman's (1904) *true-score model*, where
 * In classic test theory, true score can be estimated over multiple trials.  However, if errors are systematically biased, the true score will remain unknown.
 
 
-### Why are we concerned with reliability?  Error
+### Why are we concerned with reliability?  Error!
 
 * Measurements are imperfect and every observation has some unknown amount of error associated with it.  Two components in error:
   + **random/unsystematic**: varies in unpredictable and inconsistent ways upon repeated measurements;  sources are unknown
   + **systematic**: recurs upon repeated measurements reflecting situational or individual effects that, theoretically, could be specified.
 * Correlations are attenuated from the true correlation if the observations contain error.
-* Knowing the reliability of an instruments allows us to
-  + estimate the degree to which measured at one time and place with one instrument predict scores at another time and/or place and perhaps measured with a different instrument
+* Knowing the reliability of an instruments allows us to:
+  + estimate the degree to which measured at one time and place with one instrument predict scores at another time and/or place, and perhaps measured with a different instrument
   +  estimate the consistency of scores 
   +  estimate “…the degree to which test scores are free from errors of measurement” (APA, 1985, p. 19)
 
@@ -97,7 +97,7 @@ Figure 7.1a in Revelle's chapter illustrates the *attentuation* of the correlati
 
 * circles (latent variables) represent the *true score*
 * observed/measured/manifest variables are represented by squares and each has an associated error; not illustrated are the *random* and *systematic* components of error
-* a true score, is composed of a measured variable and its error 
+* a true score is composed of a measured variable and its error 
 * the relationship between the true scores would be stronger than the one between the measured variables
 * moving to 7.1b, the correlation between LV p and the observed '' can be estimated from the correlation of p' with a parallel test (this is the reliability piece)
 
@@ -106,7 +106,7 @@ Figure 7.2 in Revelle's Chapter 7 [-@revelle_introduction_nodate] illustrates th
 
 ### The Reliability Coefficient
 
-The symbol for reliability, $r_{xx}$, sums up the big-picture definition:  that reliability is the correlation of a measure with itself. There are a number of ways to think about it:
+The symbol for reliability, $r_{xx}$, sums up the big-picture definition that reliability is the correlation of a measure with itself. There are a number of ways to think about it:
 
 * a “theoretical validity” of a measure because it refers to a relationship between observed scores and scores on a latent variable or construct,
 * represents the fraction of an observed score variance that is not error,
@@ -114,7 +114,7 @@ The symbol for reliability, $r_{xx}$, sums up the big-picture definition:  that 
   + 1, when all observed variance is due to true-score variance; there are no random errors,
   + 0, when all observed variance is due to random errors of measurement,
 * represents the squared correlation between observed scores and true scores,
-* the ratio between true-score variance and observed score variance (for a formulaic rendition see [@pedhazur_measurement_1991]),
+* the ratio between true-score variance and observed-score variance (for a formulaic rendition see [@pedhazur_measurement_1991]),
 
 $$r_{xt}^{2}=r_{xx} =\frac{\sigma_{2}^{t}}{\sigma_{2}^{x}}$$
 where 
@@ -147,7 +147,7 @@ The research vignette for this lesson is the development and psychometric evalua
   - Heterosexism, homophobia, biphobia, transphobia, and cissexism are visible on my university/college campus. (heterosexism)
   - LGBTQ students are harassed on my university/college campus. (harassed)
 
-A [preprint](https://www.researchgate.net/publication/332062781_Perceptions_of_the_LGBTQ_College_Campus_Climate_Scale_Development_and_Psychometric_Evaluation/link/5ca0bef945851506d7377da7/download) of the article is available at ResearchGate.Below is the script for simulating item-level data from the factor loadings, means, and sample size presented in the published article. 
+A [preprint](https://www.researchgate.net/publication/332062781_Perceptions_of_the_LGBTQ_College_Campus_Climate_Scale_Development_and_Psychometric_Evaluation/link/5ca0bef945851506d7377da7/download) of the article is available at ResearchGate. Below is the script for simulating item-level data from the factor loadings, means, and sample size presented in the published article. 
 ```{r }
 set.seed(210827)
 SzyT1 <- matrix(c(.88, .73, .73, -.07,-.02, .16, -.03, .10, -.04, .86, .76, .71), ncol=2) #primary factor loadings for the two factors
@@ -196,7 +196,7 @@ The optional script below will let you save the simulated data to your computing
 psych::describe(dfSzyT1)
 ```
 
-If we look at the information about this particular scale, we recognize that the *supportive* item is scaled in the opposite direction of the rest of the items.  That is, a higher score on *supportive* would indicate a positive perception of the campus climate for LGBTQ individuals, whereas higher scores on the remaining items indicate a more negative perception. Before moving forward, we must reverse score this item.
+If we look at the information about this particular scale, we recognize that the *supportive* item is scaled in the opposite direction of the rest of the items.  That is, a higher score on *supportive* would indicate a positive perception of the campus climate for LGBTQ individuals whereas higher scores on the remaining items indicate a more negative perception. Before moving forward, we must reverse score this item.
 
 In doing this, I will briefly note that in this case I have given my variables one-word names that represent each item. Many researchers (including myself) will often give variable names that are alpha numerical:  LGBTQ1, LGBTQ2, LGBTQ*n*. Either is acceptable. In the psychometric case, the one-word names may be useful shortcuts as one begins to understand the inter-item relations.
 
@@ -236,9 +236,9 @@ If reliability is defined as the correlation between a test and a test just like
 * the internal structure of the test 
 
 
-### Split half reliability
+### Split-half reliability
 
-*Split half reliability* is splitting a test into two random halves, correlating the two halves, and adjusting the correlation with the *Spearman-Brown* prophecy formula. Abundant formulaic detail in Revelle's Chapter 7/Reliability [-@revelle_william_personality_nodate].
+*Split-half reliability* is splitting a test into two random halves, correlating the two halves, and adjusting the correlation with the *Spearman-Brown* prophecy formula. Abundant formulaic detail in Revelle's Chapter 7/Reliability [-@revelle_william_personality_nodate].
 
 An important question to split half is "How to split?"  Revelle terms it a "combinatorially difficult problem."  There are 126 possible splits for a 10 item scale, 6,345 possible splits for a 16 item scale, and over 4.5 billion for a 36 item scale!  The *psych* package's *splitHalf()* function will try all possible splits for scales of up to 16 items, then sample 10,000 splits for scales longer than that.
 
@@ -249,13 +249,13 @@ hist(split$raw,breaks = 101, xlab = "Split half reliability",
 main = "Split half reliabilities of 6 LGBTQ items")
 ```
 
-Results of the split-half can provide some indication of whether not the scale is unidimensional.
+Results of the split half can provide some indication of whether not the scale is unidimensional.
 
-In this case the maximum reliability coefficient is .78, the average .64, and the lowest is .04.  Similarly we can look at the quantiles:  .17, .71, .78.  
+In this case, the maximum reliability coefficient is .78, the average .64, and the lowest is .04.  Similarly, we can look at the quantiles:  .17, .71, .78.  
 
 The split-half output also includes the classic Cronbach's (1951) alpha coefficient (.64; aka Guttman lambda 3) and average interitem correlations (.24). The figure plots the frequencies of the reliability coefficient values. 
 
-While I did not find guidelines on what constitutes a "high enough lowerbound" to establish homogeneity, Revelle suggested that a scale with .85, 80, and .65 had "strong evidence for a relatively homogeneous scale."  When the values were .81, .73, .42, Revelle indicated that there was "strong evidence for non-homogeneity" [@revelle_reliability_2019, p. 11]. In making this declaration Revelle was also looking at the strength of the inter-item correlation and for a rather tight, bell-shaped distribution, at the higher (> .73) end of the figure. *We don't quite have that.*
+While I did not find guidelines on what constitutes a "high enough lowerbound" to establish homogeneity, Revelle suggested that a scale with .85, 80, and .65 had "strong evidence for a relatively homogeneous scale."  When the values were .81, .73, .42, Revelle indicated that there was "strong evidence for non-homogeneity" [@revelle_reliability_2019, p. 11]. In making this declaration, Revelle was also looking at the strength of the inter-item correlation and for a rather tight bell-shaped distribution at the higher (> .73) end of the figure. *We don't quite have that.*
 
 What happens when we examine the split-half estimates of the subscales?  With only three items,  there's not much of a split and so the associated histogram will not be helpful.
 
@@ -268,7 +268,7 @@ main = "Split half reliabilities of 3 items of the College Response subscale")
 
 The alpha is higher -- .79  The range of splits for max, ave, and low are .75, .96, and .69 and the quantiles are 0.69 0.72 0.75.  The inter-item correlations have an average of .57.    
 
-Let's look at the split half reliabilities for the Stigma subscale.
+Let's look at the split-half reliabilities for the Stigma subscale.
 
 ```{r }
 splitSt <- psych::splitHalf (StigmaT1, raw = TRUE, brute = TRUE)
@@ -276,9 +276,10 @@ splitSt #show the results of the analysis
 hist(splitRx$raw,breaks = 101, xlab = "Split half reliability",
 main = "Split half reliabilities of 3 items of the Stigma subscale")
 ```
-The maximum, average, and minimum split half reliabilities were .74, .96, and .70; quantiles were at .70, .72, and .74. The average interitem correlation was .56.
 
-Because the alpha coefficient can be defined as the "average of all possible split-half coefficients" for the groups tested, it is common for researchers to not provide split half results in their papers. This is true for our research vignette. I continue to teach the split half because it can be a stepping stone in the conceptualization of internal consistency as an estimate of reliability.
+The maximum, average, and minimum split-half reliabilities were .74, .96, and .70; quantiles were at .70, .72, and .74. The average inter-item correlation was .56.
+
+Because the alpha coefficient can be defined as the "average of all possible split-half coefficients" for the groups tested, it is common for researchers not to provide split-half results in their papers -- this is true for our research vignette. I continue to teach the split half because it can be a stepping stone in the conceptualization of internal consistency as an estimate of reliability.
 
 ### From alpha
 
@@ -322,17 +323,17 @@ In the case of the Stigma subscale:
 * **std.apha**, .79 is based on correlations
 * **average_r**, .56 is the average interitem correlation
 
-The documentation for this package is incredible. Scroll to near the bottom of the *alpha()* function to learn what these are.
+The documentation for this package is incredible. Scroll down near the bottom of the *alpha()* function to learn what these are.
 
 Especially useful are item-level statistics:  
 
 * **r.drop** is the corrected item-total correlation ([in the next lesson](#ItemAnalSurvey)) for this item against the scale without this item
-*,**mean** and **sd** are the mean and standard deviation of each item, across all individuals.
+*,**mean** and **sd** are the mean and standard deviation of each item across all individuals.
 
-**But don't get too excited** the popularity of alpha emerged when tools available for calculation were less sophisticated.  Alpha can be misleading:
+**But don't get too excited** ... The popularity of alpha emerged when tools available for calculation were less sophisticated --  alpha can be misleading.
   
 * alpha inflates, somewhat artificially, even when inter-item correlations are low.
-  - a 14-item scale will have an alpha of at least .70 even if it has two orthogonal (i.e., unrelated) scales [@cortina_what_1993]
+  - a 14-item scale will have an alpha of at least .70, even if it has two orthogonal (i.e., unrelated) scales [@cortina_what_1993]
 * alpha assumes a unidimensional factor structure, 
 * the same alpha can be obtained for dramatically different underlying factor structures (see graphs in Revelle's Chapter 7)
 
@@ -345,7 +346,7 @@ When either of these is violated, alpha underestimates reliability and overestim
 
 It is curious that the subscale estimates are stronger than the total scale estimates. This early evidence supports the two-scale solution. 
 
-Alpha and the split halves are *internal consistency* estimates.  Moving to *model based* techniques allows us to take into consideration the factor structure of the scale. In the original  article [@szymanski_perceptions_2020], results were as follows. Note that the alphas are stronger than in our simulation.:
+Alpha and the split halves are *internal consistency* estimates.  Moving to *model based* techniques allows us to take into consideration the factor structure of the scale. In the original  article [@szymanski_perceptions_2020], results were as follows (note that the alphas are stronger than in our simulation):
 
 |Scale (*n*)  |Alpha   |Inter-item correlation range|Average inter-item correlation
 |:-----------|:------:|:-----------:|:------:|
@@ -355,23 +356,23 @@ Alpha and the split halves are *internal consistency* estimates.  Moving to *mod
 
 In the article, we can see the boost that alpha gets (.85) when the number of items is double, even though the average inter-item correlation is lower (.49)
 
-### to Omega
+### To omega
 
-Assessing reliability with the *omega* ($\omega$)  statistics falls into a larger realm of *composite reliability* where reliability is assessed from a ratio of the variability explained by the items compared with the total variance of the entire scale [@mcneish_thanks_2018]. Members of the omega family of reliability estimates come from factor exploratory (EFA) and confirmatory (CFA; structural equation modeling (SEM) factor analytic approaches. This lesson precedes the lessons on CFA and SEM. Therefore, my explanations and demonstrations will be somewhat brief. I intend to revisit omega output in the CFA and SEM lessons and encourage you to review this section now, then return to this section again after learning more about CFA and SEM. 
+Assessing reliability with the *omega* ($\omega$)  statistics falls into a larger realm of *composite reliability* where reliability is assessed from a ratio of the variability explained by the items compared with the total variance of the entire scale [@mcneish_thanks_2018]. Members of the omega family of reliability estimates come from factor exploratory (i.e., EFA) and confirmatory (i.e., CFA; structural equation modeling (SEM)) factor analytic approaches. This lesson precedes the lessons on CFA and SEM. Therefore, my explanations and demonstrations will be somewhat brief. I intend to revisit omega output in the CFA and SEM lessons and encourage you to review this section now, then return to this section again after learning more about CFA and SEM. 
 
 In the context of *psychometrics* it may be useful (albeit an oversimplification) to think of factors as scales/subscales where *g* refers to the amount of variance in the *general* factor (or total scale score) and subcales to be items that have something in common that is separate from what is *g*.
 
-Model based estimates examine the correlations or covariances of the items and decompose the test variance into that which is 
+Model-based estimates examine the correlations or covariances of the items and decompose the test variance into that which is:
 
 * common to all items (**g**, a general factor), 
 * specific to some items (**f**, orthogonal group factors), and 
 * unique to each item (confounding **s** specific, and **e** error variance)
 
-$\omega$ is something of a shapeshifter. In the *psych* package
+$\omega$ is something of a shapeshifter. In the *psych* package:
 
 * $\omega_{t}$ represents the total reliability of the test ($\omega_{t}$)
-  + In the *psych* package, this is calculated from a bifactor model where there is one general *g* factor (i.e., each item loads on the single general factor), one or more group factors (*f*), and an item-specific factor (*s*).
-* $\omega_{h}$ extracts a higher order factor from the correlation matrix of lower level factors, then applies the Schmid and Leiman (1957) transformation to find the general loadings on the original items. Stated another way, it is a measure o f the general factor saturation (*g*; the amount of variance attributable to one comon factor). The subscript "h" acknowledges the hierarchical nature of the approach.
+  + In the *psych* package, this is calculated from a bifactor model where there is one general *g* factor (i.e., each item loads on the single general factor), one or more group factors (*f*), and an item-specific factor(*s*).
+* $\omega_{h}$ extracts a higher-order factor from the correlation matrix of lower-level factors, then applies the Schmid and Leiman (1957) transformation to find the general loadings on the original items. Stated another way, it is a measure of the general factor saturation (*g*; the amount of variance attributable to one comon factor). The subscript "h" acknowledges the hierarchical nature of the approach.
   +  the $\omega_{h}$ approach is exploratory and defined if there are three or more group factors (with only two group factors, the default is to assume they are equally important, hence the factor loadings of those subscales will be equal)
   + Najera Catalan [@najera_catalan_reliability_2019] suggests that $\omega_{h}$ is the best measure of reliability when dealing with multiple dimensions.
 * $\omega_{g}$ is an estimate that uses a bifactor solution via the SEM package *lavaan* and tends to be a larger (because it forces all the cross loadings of lower level factors to be 0)
@@ -394,28 +395,28 @@ There's a ton of output!  How do we make sense of it?
 
 First, our items aligned perfectly with their respective factors (subscales). That is, it would be problematic if the items switched factors.
 
-Second, we can interpret our results. Like alpha, the omegas range from 0 to 1, where values closer to 1 represent good reliability [@najera_catalan_reliability_2019]. For unidimensional measures, * $\omega_{t}$ values above 0.80 seem to be an indicator of good reliability.  For multidimensional measures with well-defined dimensions we strive for $\omega_{h}$ values above 0.65 (and $\omega_{t}$ > 0.8). These recommendations are based on a Monte Carlo study that examined a host of reliability indicators and how their values corresponded with accurate predictions of poverty status. With this in mind, let's examine the output related to our simulated research vignette.
+Second, we can interpret our results. Like alpha, the omegas range from 0 to 1, where values closer to 1 represent good reliability [@najera_catalan_reliability_2019]. For unidimensional measures, * $\omega_{t}$ values above 0.80 seem to be an indicator of good reliability.  For multidimensional measures with well-defined dimensions, we strive for $\omega_{h}$ values above 0.65 (and $\omega_{t}$ > 0.8). These recommendations are based on a Monte Carlo study that examined a host of reliability indicators and how their values corresponded with accurate predictions of poverty status. With this in mind, let's examine the output related to our simulated research vignette.
 
-Let's examine the output in the lower portion where the values are "from a confirmatory model using sem."
+Let's start with the output in the lower portion where the values are "from a confirmatory model using sem."
 
-Omega is a reliability estimate for factor analysis that represents the proportion of variance in the LGBTQ scale attributable to common variance, rather than error. The omega for the total reliability of the test ($\omega_{t}$; which included the general factors and the subscale factors) was .72, meaning that 72% of the variance in the total scale is due to the factors and 28% (100% - 72%) is attributable to error. 
+Omega is a reliability estimate for factor analysis that represents the proportion of variance in the LGBTQ scale attributable to common variance rather than error. The omega for the total reliability of the test ($\omega_{t}$; which included the general factors and the subscale factors) was .72, meaning that 72% of the variance in the total scale is due to the factors and 28% (100% - 72%) is attributable to error. 
 
-Omega hierarchical ($\omega_{h}$) estimates are the proportion of variance in the LGBTQ score attributable to the general factor, which in effect treats the subscales as error.  $\omega_{h}$ for the the LGBTQ total scale was .40 A quick calculation with $\omega_{h}$ (.37) and $\omega_{t}$ (.72; .40/.72 = .56) lets us know that that 56% of the reliable variance in the LGBTQ total scale is attributable to the general factor. 
+Omega hierarchical ($\omega_{h}$) estimates are the proportion of variance in the LGBTQ score attributable to the general factor, which in effect treats the subscales as error.  $\omega_{h}$ for the the LGBTQ total scale was .40. A quick calculation with $\omega_{h}$ (.37) and $\omega_{t}$ (.72; .40/.72 = .56) lets us know that that 56% of the reliable variance in the LGBTQ total scale is attributable to the general factor. 
 
 ```{r}
 .4/.72
 ```
 
-Amongst the output is the Cronbach's alpha coefficient (.66). Szymanski and Bissonette [@szymanski_perceptions_2020] did not report omega results; this may be because there were only two subfactors and/or they did not feel like a bifactor analysis would be appropriate.
+Amongst the output is the Cronbach's alpha coefficient (.66). Szymanski and Bissonette [-@szymanski_perceptions_2020] did not report omega results; this may be because there were only two subfactors and/or they did not feel like a bifactor analysis would be appropriate.
 
 ### Some summary statements about reliability from single administrations
 
-* With the exception of the worst split half-reliability and $\omega_{g}$ or $\omega_{h}$, all of the reliability estimates are functions of test length and will tend asymptotically towards 1 as the number of items increases
+* With the exception of the worst split-half reliability and $\omega_{g}$ or $\omega_{h}$, all of the reliability estimates are functions of test length and will tend asymptotically towards 1 as the number of items increases
 * the omega output provides a great deal more information about reliability than a simple alpha
   +  Figure 7.5 in Revelle's chapter shows four different structural representations of measures that have equal alphas (all .72)
-* $\omega_{(h)}$, $\beta$, and the worst split half reliability are estimates of the amount of general factor variance in the test scores
+* $\omega_{(h)}$, $\beta$, and the worst split-half reliability are estimates of the amount of general factor variance in the test scores
 * in the case of low general factor saturation, the EFA based $\omega_{(h)}$ is positively biased, so the CFA-based estimate, $\omega_{(g)}$, should be used
-* $\omega_{(t)}$ is the model based estimate of the greatest lower bound of the total reliability of the test; so is the best split half reliability
+* $\omega_{(t)}$ is the model based estimate of the greatest lower bound of the total reliability of the test; so is the best split-half reliability
 
 Revelle and Condon's [@revelle_reliability_2019] recommendations to researchers:
 
@@ -431,7 +432,7 @@ The purpose of test-retest reliability is to understand the stability of the mea
 
 * With two time points we cannot distinguish between trait and state effects, that said
   - we would expect a high degree of stability if the retest is (relatively) immediate
-* With three time points we can leverage some SEM tools to distinguish between trait and state components
+* With three time points, we can leverage some SEM tools to distinguish between trait and state components
 * A large test-retest correlation over a long period of time indicates temporal stability; 
   + expected if we are assessing something trait like (e.g., cognitive ability, personality trait) 
   + not expected if we are assessing something state like (e.g., emotional state, mood)
@@ -439,9 +440,9 @@ The purpose of test-retest reliability is to understand the stability of the mea
   
 There are some *methodological* concerns about test-retest reliability.  For example, owing to memory and learning effects, the average response time to a second administration of identical items is about 80% the time of the first administration.
 
-Szymanski and Bissonette [-@szymanski_perceptions_2020] did not assess retest reliability. We can, though imagine how this might work. Let's imagine that both waves were taken in the same academic term, approximately two weeks apart.
+Szymanski and Bissonette [-@szymanski_perceptions_2020] did not assess retest reliability. We can, though, imagine how this might work. Let's imagine that both waves were taken in the same academic term, approximately two weeks apart.
 
-With both sets of data we need to create scores for the total scale score and the two subscales. We would also need to join the two datasets into a single dataframe. We could do either, first.  I think I would create the scale scores in each df, separately. 
+With both sets of data, we need to create scores for the total scale score and the two subscales. We would also need to join the two datasets into a single dataframe. We could do either first.  I think I would create the scale scores in each df, separately. 
 
 In preparing this lesson, I considered several options. While I could (and actually did, but then deleted it) simulate item-level T2 data, I don't have an easy way to correlate it with the T1 data. The resulting test-retest is absurdly low. So, I will quickly demonstrate how you would score the item-level data for the total and subscale scores, then resimulate scale-level data that is correlated to demonstrate the retest reliability.
 
@@ -456,7 +457,7 @@ dfSzyT1$ResponseT1 <- sjstats::mean_n(dfSzyT1[,ResponseVars], .80)#will create t
 dfSzyT1$StigmaT1 <- sjstats::mean_n(dfSzyT1[,Stigmavars], .80)#will create the mean for each individual if 80% of variables are present (in this case all variables must be present)
 ```
 
-We would need to repeat this process with our retest (T2) data, save baby dfs with our scale and total scale scores and then join them. 
+We would need to repeat this process with our retest (T2) data, save baby dfs with our scale and total scale scores, and then join them. 
 
 To demonstrate the retest reliability, I have taken a different path.  In order for us to get sensible answers, I went ahead and simulated a new dataset with total and subscale scores for our variables for both waves. This next script is simply that simulation (i.e., you can skip over it).
 
@@ -480,7 +481,7 @@ retest_df <- retest_df %>% dplyr::mutate(ID = row_number()) #add ID to each row
 retest_df <- retest_df %>%dplyr::select(ID, everything())#moving the ID number to the first column; requires
 ```
 
-Examing our df, we can see the ID variable and the three sets of scores for each wave of analysis. Now we simply ask for their correlations. There are a number of ways to do this, the *apaTables* package can do the calculations and pop it into a manuscript-ready table.
+Examing our df, we can see the ID variable and the three sets of scores for each wave of analysis. Now we simply ask for their correlations. There are a number of ways to do this -- the *apaTables* package can do the calculations and pop it into a manuscript-ready table.
 
 We won't want the ID variable to be in the table.
 
@@ -498,7 +499,7 @@ As expected in this simulation,
 
 * the strongest correlations are within each scale at their respective time, that is t
   - the T1 variables correlate with each other; 
-  - the T2 variables correlate with each other). 
+  - the T2 variables correlate with each other. 
 * the next strongest correlations are with the same scale/subscale configuration across time, for example
   - TotalT1 with TotalT2
   - ResponseT1 with ResponseT2
@@ -509,16 +510,16 @@ As expected in this simulation,
 
 ### Test Retest Recap
 
-Here are some summary notions for retest reliability.
+Here are some summary notions for retest reliability:
 
-* increases in the interval will lower the reliability coefficient
-* an experimental intervention that is designed to impact the retest assessment will lower the reliability coefficient
-* state measures will have lower retest coefficients than trait measures
+* increases in the interval will lower the reliability coefficient,
+* an experimental intervention that is designed to impact the retest assessment will lower the reliability coefficient,
+* state measures will have lower retest coefficients than trait measures,
 * and those all interact with each other
 
 Note:  there are numerous demonstrations in the Revelle and Condon [-@revelle_reliability_2019; -@revelle_reliability_2019-1] materials (Table 1).  In addition to the myriad of vignettes used to illustrate foci on state, trait, items, whole scale, etc., there were demos on duplicated items, assessing for consistency, and parallel/alternate forms.
 
-If you are asking, "Hey, is parallel/alternate forms really a variant of test retest?"  Great question!  In fact, split-half could be seen as test-retest... once you get in the weeds, the distinctions become less clear.
+If you are asking, "Hey, is parallel/alternate forms really a variant of test retest?"  Great question!  In fact, split-half could be seen as test-retest... Once you get in the weeds, the distinctions become less clear.
 
 ## Interrater Reliability
 
@@ -594,7 +595,7 @@ psych::ICC(ICC_df [1:10,1:5], lmer = TRUE) #find the ICCs for the 10 campus unit
 ```
 In the output, reliability for a single judge $ICC_1$ is the ratio of person variance to total variance.  Reliability for multiple judges $ICC_1k$ adjusts the residual variance by the number of judges.
 
-The ICC function reports six reliability coefficients:  3 for the case of single judges, 3 for the case of multiple judges.  It also reports the results in terms of a traditional ANOVA as well as a mixed effects linear model, and CIs for each coefficient.
+The ICC function reports six reliability coefficients:  3 for the case of single judges and 3 for the case of multiple judges.  It also reports the results in terms of a traditional ANOVA as well as a mixed effects linear model, and CIs for each coefficient.
 
 Like most correlation coefficients, the ICC ranges from 0 to 1.
 
@@ -631,11 +632,11 @@ the reliability coefficient is also a player.
 
 ### How do I keep it all straight?
 
-Table 1 in Revelle and Condon's [@revelle_reliability_2019] article helps us connect the the type of reliability we are seeking with the statistic(s) and the R function within the *psych* package.
+Table 1 in Revelle and Condon's [-@revelle_reliability_2019] article helps us connect the the type of reliability we are seeking with the statistic(s) and the R function within the *psych* package.
 
 ## Practice Problems
    
-In each of these lessons I provide suggestions for practice that allow you to select one or more problems that are graded in difficulty. The practice problems are the start of a larger project that spans multiple lessons. Therefore,if possible, please use a dataset that has item-level data for which there is a theorized total scale score as well as two or more subscales.  With each of these options I encourage you to:
+In each of these lessons, I provide suggestions for practice that allow you to select one or more problems that are graded in difficulty. The practice problems are the start of a larger project that spans multiple lessons. Therefore,if possible, please use a dataset that has item-level data for which there is a theorized total scale score as well as two or more subscales.  With each of these options I encourage you to:
 
 * Format (i.e., rescore if necessary) a dataset so that it is possible to calculates estimates of internal consistency
 * Calculate and report the alpha coefficient for a total scale scores and subscales (if the scale has them)


### PR DESCRIPTION
There was a couple of times where I tried to mirror what you did in the code so that if you referenced an author, it didn't appear twice. For example, it may have originally read something like, "Jones and Jones (Jones & Jones, 2021)", and I tried to make it so it would appear like, "Jones and Jones (2021)" instead... I am not sure if it worked, but that was my goal. ;) Also, let me know if this doesn't make sense. It was hard to articulate via a typed message. 